### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## How to use these files
 
-* Copy docker to /etc/init.d
+* Copy docker to /etc/rc.d/init.d
 * Copy the remaining files to /etc/sysconfig/network-scripts. This will overwrite ec2net-functions.
 * Create the required symlinks:
 ```    


### PR DESCRIPTION
 /etc/init.d  is a sym link to /etc/rc.d/init.d

Trivial change, but I created a tar that extracted from root to drop all the files in the right place. Doing so replaced the link on my instance with an actual directory that contained the single docker command.  (And that was bad.)  The clarification may save someone else some time.
